### PR TITLE
Improve education rendering to show "at" only when degree and institution exist

### DIFF
--- a/app/utils/templateRenderers.ts
+++ b/app/utils/templateRenderers.ts
@@ -56,7 +56,9 @@ export const generateEducationContent = (education: Education[], t?: TranslateFu
         const at = t ? t('template.at') : ' at ';
         const separator = t ? t('template.separator') : ', ';
         const gradeLabel = t ? t('template.grade') : 'Grade:';
-        const title = `${edu.degree}${edu.institution ? ' ' + edu.institution : ''}${edu.location ? separator + edu.location : ''}`;
+        const title = edu.degree && edu.institution
+            ? `${edu.degree}${at}${edu.institution}${edu.location ? separator + edu.location : ''}`
+            : `${edu.degree || edu.institution}${edu.location ? separator + edu.location : ''}`;
         const dateRange = convertDateRange(edu.startDate, edu.endDate, edu.isPresent || false, t);
         let additionalInfo = '';
         if (edu.graduationScore && edu.graduationScore.trim()) {

--- a/app/utils/templateRenderers.ts
+++ b/app/utils/templateRenderers.ts
@@ -56,7 +56,7 @@ export const generateEducationContent = (education: Education[], t?: TranslateFu
         const at = t ? t('template.at') : ' at ';
         const separator = t ? t('template.separator') : ', ';
         const gradeLabel = t ? t('template.grade') : 'Grade:';
-        const title = `${edu.degree}${edu.institution ? at + edu.institution : ''}${edu.location ? separator + edu.location : ''}`;
+        const title = `${edu.degree}${edu.institution ? ' ' + edu.institution : ''}${edu.location ? separator + edu.location : ''}`;
         const dateRange = convertDateRange(edu.startDate, edu.endDate, edu.isPresent || false, t);
         let additionalInfo = '';
         if (edu.graduationScore && edu.graduationScore.trim()) {


### PR DESCRIPTION
This change improves the education render behavior by displaying the word "at"
only when both the degree and institution fields are provided.

The existing form behavior remains unchanged, following maintainer feedback.

Fixes #18